### PR TITLE
Update CI workflow and docs for TypeScript migration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -154,8 +154,10 @@ npm run deploy
 ```
 
 ### AI Agent Integration
-- Custom Claude commands in `.claude/commands/` provide specialized reviews
-- Node-focused agents: node-architect, node-tester, node-engineer-reviewer
+- Custom Claude commands provide specialized reviews:
+  - `/project:node-architect` - Reviews API design, TypeScript patterns, error handling, and module structure
+  - `/project:node-tester` - Generates comprehensive tests with Vitest patterns and HTTP handler tests
+  - `/project:node-engineer-reviewer` - Conducts thorough code review across quality, security, and performance
 - GitHub Actions workflow runs tests on PRs
 
 ## Code Quality Standards

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,26 +1,38 @@
-name: Go Tests
+name: Calculator Tests
 
 on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '**.go'
+      - 'services/calculator/**'
 
 jobs:
   test:
-    name: Run Go Tests
+    name: Run Calculator Tests
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          go-version: '1.21'
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/calculator/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd services/calculator
+          npm ci
+
+      - name: Run type check
+        run: |
+          cd services/calculator
+          npm run typecheck
 
       - name: Run tests
         run: |
           cd services/calculator
-          go test ./... -v
+          npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,18 +80,15 @@ This repo includes three specialized Node/TypeScript agents as custom commands:
 - `/project:node-tester` - Generates comprehensive tests with Vitest patterns and HTTP handler tests
 - `/project:node-engineer-reviewer` - Conducts thorough code review across quality, security, and performance
 
-## Automated CI/CD Agents
+## Automated CI/CD
 
-Python scripts in `scripts/agents/` run as GitHub Actions on PRs:
+GitHub Actions workflow (`.github/workflows/ai-code-review.yml`) automatically runs tests on PRs:
 
 ```bash
-# Install dependencies
-pip install -r scripts/agents/requirements.txt
-
-# Run locally (requires ANTHROPIC_API_KEY)
-python scripts/agents/go_architect.py
-python scripts/agents/go_tester.py
-python scripts/agents/go_engineer_reviewer.py --diff
+# CI runs these commands on each PR
+npm ci
+npm run typecheck
+npm test
 ```
 
-GitHub Actions workflow (`.github/workflows/ai-code-review.yml`) automatically posts review comments on PRs. Requires `ANTHROPIC_API_KEY` secret in repository settings.
+The workflow triggers on changes to `services/calculator/**` files.


### PR DESCRIPTION
## Summary

- Updates GitHub Actions workflow from Go tests to npm tests
- Rewrites copilot-instructions.md with TypeScript/Node patterns

## Changes

### `.github/workflows/ai-code-review.yml`
- Renamed from "Go Tests" to "Calculator Tests"
- Uses Node.js 20 with npm caching
- Runs `npm ci`, `npm run typecheck`, and `npm test`
- Triggers on `services/calculator/**` instead of `**.go`

### `.github/copilot-instructions.md`
- Updated project description for TypeScript/Cloudflare Workers
- Changed architecture diagram to show TypeScript structure
- Replaced Go code examples with TypeScript equivalents
- Updated build commands from `go` to `npm`
- Changed reference file paths to TypeScript sources

## Test plan

- [x] Changes are consistent with the TypeScript migration in PR #8
- [ ] Verify CI workflow triggers on calculator changes
- [ ] Verify workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)